### PR TITLE
修复失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,10 +362,10 @@ MIT License — 详见 [LICENSE](LICENSE)
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=jiangtaovan%2Ftdxrs&type=Date">
+<a href="https://star-history.dera.page/#jiangtaovan/tdxrs&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jiangtaovan/tdxrs&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jiangtaovan/tdxrs&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jiangtaovan/tdxrs&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=jiangtaovan/tdxrs&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=jiangtaovan/tdxrs&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=jiangtaovan/tdxrs&type=Date" />
  </picture>
 </a>

--- a/README_en.md
+++ b/README_en.md
@@ -362,10 +362,10 @@ MIT License — see [LICENSE](LICENSE)
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=jiangtaovan%2Ftdxrs&type=Date">
+<a href="https://star-history.dera.page/#jiangtaovan/tdxrs&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jiangtaovan/tdxrs&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jiangtaovan/tdxrs&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jiangtaovan/tdxrs&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=jiangtaovan/tdxrs&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=jiangtaovan/tdxrs&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=jiangtaovan/tdxrs&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
当前 Star History 图表无法正常显示。本变更更新 README 中的图表链接，恢复项目 star history 的正常展示。